### PR TITLE
DAND-16-Setup iOS MonoRepo (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,8 @@ xcuserdata/
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
-# Pods/
+
+Pods/
 
 # Carthage
 #

--- a/Example Projects/Simple Integrations Example/Podfile
+++ b/Example Projects/Simple Integrations Example/Podfile
@@ -1,0 +1,23 @@
+# Uncomment the next line to define a global platform for your project
+
+platform :ios, '9.0'
+use_frameworks!
+
+def testing_pods
+  pod 'Expecta'
+  pod 'Specta'
+end
+
+target 'Simple Integrations Example' do
+  
+  pod 'Segment-Facebook-App-Events', :path => '../../Integrations/analytics-ios-integration-facebook-app-events'
+ 
+ target 'Simple Integrations ExampleTests' do
+  testing_pods
+  end
+end
+
+
+
+
+

--- a/Example Projects/Simple Integrations Example/Podfile.lock
+++ b/Example Projects/Simple Integrations Example/Podfile.lock
@@ -1,0 +1,40 @@
+PODS:
+  - Analytics (3.7.0)
+  - Expecta (1.0.6)
+  - FBSDKCoreKit (5.13.1):
+    - FBSDKCoreKit/Basics (= 5.13.1)
+    - FBSDKCoreKit/Core (= 5.13.1)
+  - FBSDKCoreKit/Basics (5.13.1)
+  - FBSDKCoreKit/Core (5.13.1):
+    - FBSDKCoreKit/Basics
+  - Segment-Facebook-App-Events (1.0.4):
+    - Analytics (~> 3.0)
+    - FBSDKCoreKit (~> 5.0)
+  - Specta (1.0.7)
+
+DEPENDENCIES:
+  - Expecta
+  - Segment-Facebook-App-Events (from `../../Integrations/analytics-ios-integration-facebook-app-events`)
+  - Specta
+
+SPEC REPOS:
+  trunk:
+    - Analytics
+    - Expecta
+    - FBSDKCoreKit
+    - Specta
+
+EXTERNAL SOURCES:
+  Segment-Facebook-App-Events:
+    :path: "../../Integrations/analytics-ios-integration-facebook-app-events"
+
+SPEC CHECKSUMS:
+  Analytics: 77fd5fb102a4a5eedafa2c2b0245ceb7b7c15e45
+  Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
+  FBSDKCoreKit: 8fb98209109fb684937f05d534305edb18c20207
+  Segment-Facebook-App-Events: fc089c58a163dbfb817a8a65b2e5023afd919843
+  Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
+
+PODFILE CHECKSUM: fca958077eed15b55edfd1be4a345eff84fd884e
+
+COCOAPODS: 1.8.4

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example.xcodeproj/project.pbxproj
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example.xcodeproj/project.pbxproj
@@ -1,0 +1,597 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		00943BF8D7241E5871A6F493 /* Pods_Simple_Integrations_Example_Simple_Integrations_ExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C10A5B6528620BE5B204C0B /* Pods_Simple_Integrations_Example_Simple_Integrations_ExampleTests.framework */; };
+		65EF898118CF6063F185B4D8 /* Pods_Simple_Integrations_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9826CE3BF476BAD9D990506 /* Pods_Simple_Integrations_Example.framework */; };
+		E072C643238629E200F90DC6 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = E072C642238629E200F90DC6 /* AppDelegate.m */; };
+		E072C646238629E200F90DC6 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E072C645238629E200F90DC6 /* ViewController.m */; };
+		E072C649238629E200F90DC6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E072C647238629E200F90DC6 /* Main.storyboard */; };
+		E072C64B238629E300F90DC6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E072C64A238629E300F90DC6 /* Assets.xcassets */; };
+		E072C64E238629E300F90DC6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E072C64C238629E300F90DC6 /* LaunchScreen.storyboard */; };
+		E072C651238629E300F90DC6 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E072C650238629E300F90DC6 /* main.m */; };
+		E072C65B238629E300F90DC6 /* Simple_Integrations_ExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E072C65A238629E300F90DC6 /* Simple_Integrations_ExampleTests.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		E072C657238629E300F90DC6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E072C636238629E200F90DC6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E072C63D238629E200F90DC6;
+			remoteInfo = "Simple Integrations Example";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		06C0C19FFF650E24B20C66E9 /* Pods-Common-Simple Integrations Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-Simple Integrations Example.release.xcconfig"; path = "Target Support Files/Pods-Common-Simple Integrations Example/Pods-Common-Simple Integrations Example.release.xcconfig"; sourceTree = "<group>"; };
+		1636C864E2C40AB43C5AF556 /* Pods-Simple Integrations ExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Simple Integrations ExampleTests.release.xcconfig"; path = "Target Support Files/Pods-Simple Integrations ExampleTests/Pods-Simple Integrations ExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		1CF1B132F340C9A6D53BD33F /* Pods-Common-Simple Integrations Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-Simple Integrations Example.debug.xcconfig"; path = "Target Support Files/Pods-Common-Simple Integrations Example/Pods-Common-Simple Integrations Example.debug.xcconfig"; sourceTree = "<group>"; };
+		2631E269C697C8AD9DC50B1D /* Pods-Simple Integrations Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Simple Integrations Example.release.xcconfig"; path = "../Example Projects/Simple Integrations Example/Pods/Target Support Files/Pods-Simple Integrations Example/Pods-Simple Integrations Example.release.xcconfig"; sourceTree = "<group>"; };
+		2A308232B8179E92F9247E02 /* Pods-Common-Simple Integrations Example-Simple Integrations ExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-Simple Integrations Example-Simple Integrations ExampleTests.release.xcconfig"; path = "Target Support Files/Pods-Common-Simple Integrations Example-Simple Integrations ExampleTests/Pods-Common-Simple Integrations Example-Simple Integrations ExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		2E9CC569D4CC8528EC195D88 /* Pods-Simple Integrations Example-Simple Integrations ExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Simple Integrations Example-Simple Integrations ExampleTests.debug.xcconfig"; path = "../Example Projects/Simple Integrations Example/Pods/Target Support Files/Pods-Simple Integrations Example-Simple Integrations ExampleTests/Pods-Simple Integrations Example-Simple Integrations ExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		76447BDE7F7F449289A89BB1 /* Pods-Simple Integrations Example-Simple Integrations ExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Simple Integrations Example-Simple Integrations ExampleTests.release.xcconfig"; path = "../Example Projects/Simple Integrations Example/Pods/Target Support Files/Pods-Simple Integrations Example-Simple Integrations ExampleTests/Pods-Simple Integrations Example-Simple Integrations ExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		7C10A5B6528620BE5B204C0B /* Pods_Simple_Integrations_Example_Simple_Integrations_ExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Simple_Integrations_Example_Simple_Integrations_ExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C0738114D02C240EED1AD23B /* Pods-Simple Integrations Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Simple Integrations Example.debug.xcconfig"; path = "../Example Projects/Simple Integrations Example/Pods/Target Support Files/Pods-Simple Integrations Example/Pods-Simple Integrations Example.debug.xcconfig"; sourceTree = "<group>"; };
+		C9826CE3BF476BAD9D990506 /* Pods_Simple_Integrations_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Simple_Integrations_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E072C63E238629E200F90DC6 /* Simple Integrations Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Simple Integrations Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E072C641238629E200F90DC6 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		E072C642238629E200F90DC6 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		E072C644238629E200F90DC6 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		E072C645238629E200F90DC6 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		E072C648238629E200F90DC6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		E072C64A238629E300F90DC6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E072C64D238629E300F90DC6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		E072C64F238629E300F90DC6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E072C650238629E300F90DC6 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		E072C656238629E300F90DC6 /* Simple Integrations ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Simple Integrations ExampleTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E072C65A238629E300F90DC6 /* Simple_Integrations_ExampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Simple_Integrations_ExampleTests.m; sourceTree = "<group>"; };
+		E072C65C238629E300F90DC6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F865FC6B2AF35B416201C445 /* Pods-Simple Integrations ExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Simple Integrations ExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-Simple Integrations ExampleTests/Pods-Simple Integrations ExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		FA2992D6723E790D248DD108 /* Pods-Common-Simple Integrations Example-Simple Integrations ExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-Simple Integrations Example-Simple Integrations ExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-Common-Simple Integrations Example-Simple Integrations ExampleTests/Pods-Common-Simple Integrations Example-Simple Integrations ExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E072C63B238629E200F90DC6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65EF898118CF6063F185B4D8 /* Pods_Simple_Integrations_Example.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E072C653238629E300F90DC6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				00943BF8D7241E5871A6F493 /* Pods_Simple_Integrations_Example_Simple_Integrations_ExampleTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4A02838C5FE4509D2A862B7E /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				C0738114D02C240EED1AD23B /* Pods-Simple Integrations Example.debug.xcconfig */,
+				2631E269C697C8AD9DC50B1D /* Pods-Simple Integrations Example.release.xcconfig */,
+				F865FC6B2AF35B416201C445 /* Pods-Simple Integrations ExampleTests.debug.xcconfig */,
+				1636C864E2C40AB43C5AF556 /* Pods-Simple Integrations ExampleTests.release.xcconfig */,
+				1CF1B132F340C9A6D53BD33F /* Pods-Common-Simple Integrations Example.debug.xcconfig */,
+				06C0C19FFF650E24B20C66E9 /* Pods-Common-Simple Integrations Example.release.xcconfig */,
+				FA2992D6723E790D248DD108 /* Pods-Common-Simple Integrations Example-Simple Integrations ExampleTests.debug.xcconfig */,
+				2A308232B8179E92F9247E02 /* Pods-Common-Simple Integrations Example-Simple Integrations ExampleTests.release.xcconfig */,
+				2E9CC569D4CC8528EC195D88 /* Pods-Simple Integrations Example-Simple Integrations ExampleTests.debug.xcconfig */,
+				76447BDE7F7F449289A89BB1 /* Pods-Simple Integrations Example-Simple Integrations ExampleTests.release.xcconfig */,
+			);
+			name = Pods;
+			path = ../../Pods;
+			sourceTree = "<group>";
+		};
+		7CA5EB0AD83B868FD8C198C3 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				C9826CE3BF476BAD9D990506 /* Pods_Simple_Integrations_Example.framework */,
+				7C10A5B6528620BE5B204C0B /* Pods_Simple_Integrations_Example_Simple_Integrations_ExampleTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E072C635238629E200F90DC6 = {
+			isa = PBXGroup;
+			children = (
+				E072C640238629E200F90DC6 /* Simple Integrations Example */,
+				E072C659238629E300F90DC6 /* Simple Integrations ExampleTests */,
+				E072C63F238629E200F90DC6 /* Products */,
+				4A02838C5FE4509D2A862B7E /* Pods */,
+				7CA5EB0AD83B868FD8C198C3 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		E072C63F238629E200F90DC6 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E072C63E238629E200F90DC6 /* Simple Integrations Example.app */,
+				E072C656238629E300F90DC6 /* Simple Integrations ExampleTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E072C640238629E200F90DC6 /* Simple Integrations Example */ = {
+			isa = PBXGroup;
+			children = (
+				E072C641238629E200F90DC6 /* AppDelegate.h */,
+				E072C642238629E200F90DC6 /* AppDelegate.m */,
+				E072C644238629E200F90DC6 /* ViewController.h */,
+				E072C645238629E200F90DC6 /* ViewController.m */,
+				E072C647238629E200F90DC6 /* Main.storyboard */,
+				E072C64A238629E300F90DC6 /* Assets.xcassets */,
+				E072C64C238629E300F90DC6 /* LaunchScreen.storyboard */,
+				E072C64F238629E300F90DC6 /* Info.plist */,
+				E072C650238629E300F90DC6 /* main.m */,
+			);
+			path = "Simple Integrations Example";
+			sourceTree = "<group>";
+		};
+		E072C659238629E300F90DC6 /* Simple Integrations ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				E072C65A238629E300F90DC6 /* Simple_Integrations_ExampleTests.m */,
+				E072C65C238629E300F90DC6 /* Info.plist */,
+			);
+			path = "Simple Integrations ExampleTests";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E072C63D238629E200F90DC6 /* Simple Integrations Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E072C65F238629E300F90DC6 /* Build configuration list for PBXNativeTarget "Simple Integrations Example" */;
+			buildPhases = (
+				3A7D016899E3A0A451DDEE35 /* [CP] Check Pods Manifest.lock */,
+				E072C63A238629E200F90DC6 /* Sources */,
+				E072C63B238629E200F90DC6 /* Frameworks */,
+				E072C63C238629E200F90DC6 /* Resources */,
+				BE8D62EAAFA7F7B2976C3689 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Simple Integrations Example";
+			productName = "Simple Integrations Example";
+			productReference = E072C63E238629E200F90DC6 /* Simple Integrations Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+		E072C655238629E300F90DC6 /* Simple Integrations ExampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E072C662238629E300F90DC6 /* Build configuration list for PBXNativeTarget "Simple Integrations ExampleTests" */;
+			buildPhases = (
+				C2DE2BEFB989972CDBB030B7 /* [CP] Check Pods Manifest.lock */,
+				E072C652238629E300F90DC6 /* Sources */,
+				E072C653238629E300F90DC6 /* Frameworks */,
+				E072C654238629E300F90DC6 /* Resources */,
+				6486A8DBF083A748F915C03D /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E072C658238629E300F90DC6 /* PBXTargetDependency */,
+			);
+			name = "Simple Integrations ExampleTests";
+			productName = "Simple Integrations ExampleTests";
+			productReference = E072C656238629E300F90DC6 /* Simple Integrations ExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E072C636238629E200F90DC6 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1030;
+				ORGANIZATIONNAME = Segment;
+				TargetAttributes = {
+					E072C63D238629E200F90DC6 = {
+						CreatedOnToolsVersion = 10.3;
+					};
+					E072C655238629E300F90DC6 = {
+						CreatedOnToolsVersion = 10.3;
+						TestTargetID = E072C63D238629E200F90DC6;
+					};
+				};
+			};
+			buildConfigurationList = E072C639238629E200F90DC6 /* Build configuration list for PBXProject "Simple Integrations Example" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E072C635238629E200F90DC6;
+			productRefGroup = E072C63F238629E200F90DC6 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E072C63D238629E200F90DC6 /* Simple Integrations Example */,
+				E072C655238629E300F90DC6 /* Simple Integrations ExampleTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E072C63C238629E200F90DC6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E072C64E238629E300F90DC6 /* LaunchScreen.storyboard in Resources */,
+				E072C64B238629E300F90DC6 /* Assets.xcassets in Resources */,
+				E072C649238629E200F90DC6 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E072C654238629E300F90DC6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		3A7D016899E3A0A451DDEE35 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Simple Integrations Example-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6486A8DBF083A748F915C03D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Simple Integrations Example-Simple Integrations ExampleTests/Pods-Simple Integrations Example-Simple Integrations ExampleTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Simple Integrations Example-Simple Integrations ExampleTests/Pods-Simple Integrations Example-Simple Integrations ExampleTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Simple Integrations Example-Simple Integrations ExampleTests/Pods-Simple Integrations Example-Simple Integrations ExampleTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		BE8D62EAAFA7F7B2976C3689 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Simple Integrations Example/Pods-Simple Integrations Example-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Simple Integrations Example/Pods-Simple Integrations Example-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Simple Integrations Example/Pods-Simple Integrations Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C2DE2BEFB989972CDBB030B7 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Simple Integrations Example-Simple Integrations ExampleTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E072C63A238629E200F90DC6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E072C646238629E200F90DC6 /* ViewController.m in Sources */,
+				E072C651238629E300F90DC6 /* main.m in Sources */,
+				E072C643238629E200F90DC6 /* AppDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E072C652238629E300F90DC6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E072C65B238629E300F90DC6 /* Simple_Integrations_ExampleTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E072C658238629E300F90DC6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E072C63D238629E200F90DC6 /* Simple Integrations Example */;
+			targetProxy = E072C657238629E300F90DC6 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		E072C647238629E200F90DC6 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E072C648238629E200F90DC6 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		E072C64C238629E300F90DC6 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E072C64D238629E300F90DC6 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		E072C65D238629E300F90DC6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		E072C65E238629E300F90DC6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		E072C660238629E300F90DC6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C0738114D02C240EED1AD23B /* Pods-Simple Integrations Example.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Simple Integrations Example/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Segment.Simple-Integrations-Example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E072C661238629E300F90DC6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2631E269C697C8AD9DC50B1D /* Pods-Simple Integrations Example.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Simple Integrations Example/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Segment.Simple-Integrations-Example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		E072C663238629E300F90DC6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2E9CC569D4CC8528EC195D88 /* Pods-Simple Integrations Example-Simple Integrations ExampleTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Simple Integrations ExampleTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Segment.Simple-Integrations-ExampleTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Simple Integrations Example.app/Simple Integrations Example";
+			};
+			name = Debug;
+		};
+		E072C664238629E300F90DC6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 76447BDE7F7F449289A89BB1 /* Pods-Simple Integrations Example-Simple Integrations ExampleTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Simple Integrations ExampleTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Segment.Simple-Integrations-ExampleTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Simple Integrations Example.app/Simple Integrations Example";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E072C639238629E200F90DC6 /* Build configuration list for PBXProject "Simple Integrations Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E072C65D238629E300F90DC6 /* Debug */,
+				E072C65E238629E300F90DC6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E072C65F238629E300F90DC6 /* Build configuration list for PBXNativeTarget "Simple Integrations Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E072C660238629E300F90DC6 /* Debug */,
+				E072C661238629E300F90DC6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E072C662238629E300F90DC6 /* Build configuration list for PBXNativeTarget "Simple Integrations ExampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E072C663238629E300F90DC6 /* Debug */,
+				E072C664238629E300F90DC6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = E072C636238629E200F90DC6 /* Project object */;
+}

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Simple Integrations Example.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example.xcworkspace/contents.xcworkspacedata
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Simple Integrations Example.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example/AppDelegate.h
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example/AppDelegate.h
@@ -1,0 +1,17 @@
+//
+//  AppDelegate.h
+//  Simple Integrations Example
+//
+//  Created by Olla Ashour on 11/21/19.
+//  Copyright © 2019 Segment. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+
+@end
+

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example/AppDelegate.m
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example/AppDelegate.m
@@ -1,0 +1,69 @@
+//
+//  AppDelegate.m
+//  Simple Integrations Example
+//
+//  Created by Olla Ashour on 11/21/19.
+//  Copyright © 2019 Segment. All rights reserved.
+//
+
+#import "AppDelegate.h"
+#import <Analytics/SEGAnalytics.h>
+#import <SEGFacebookAppEventsIntegrationFactory.h>
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    
+    // Override point for customization after application launch.
+    [SEGAnalytics debug:YES];
+    SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"gnjyuUpq7mZYtLM76mwltoiZcDsFpnfY"];
+    
+    // Add any of your bundled integrations.
+    [config use:[SEGFacebookAppEventsIntegrationFactory instance]];
+    
+    [SEGAnalytics setupWithConfiguration:config];
+    
+    [[SEGAnalytics sharedAnalytics] identify:@"segment-fake-tester"
+                                      traits:@{ @"email": @"tool@fake-segment-tester.com" }];
+    
+    [[SEGAnalytics sharedAnalytics] track:@"Completed Order"
+                               properties:@{ @"title": @"Launch Screen", @"revenue": @14.50 }];
+    
+    return YES;
+}
+
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+}
+
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+}
+
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+
+@end

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example/Assets.xcassets/Contents.json
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example/Base.lproj/LaunchScreen.storyboard
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example/Base.lproj/Main.storyboard
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example/Info.plist
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example/ViewController.h
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example/ViewController.h
@@ -1,0 +1,15 @@
+//
+//  ViewController.h
+//  Simple Integrations Example
+//
+//  Created by Olla Ashour on 11/21/19.
+//  Copyright © 2019 Segment. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example/ViewController.m
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example/ViewController.m
@@ -1,0 +1,23 @@
+//
+//  ViewController.m
+//  Simple Integrations Example
+//
+//  Created by Olla Ashour on 11/21/19.
+//  Copyright © 2019 Segment. All rights reserved.
+//
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
+
+@end

--- a/Example Projects/Simple Integrations Example/Simple Integrations Example/main.m
+++ b/Example Projects/Simple Integrations Example/Simple Integrations Example/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  Simple Integrations Example
+//
+//  Created by Olla Ashour on 11/21/19.
+//  Copyright © 2019 Segment. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/Example Projects/Simple Integrations Example/Simple Integrations ExampleTests/Info.plist
+++ b/Example Projects/Simple Integrations Example/Simple Integrations ExampleTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Example Projects/Simple Integrations Example/Simple Integrations ExampleTests/Simple_Integrations_ExampleTests.m
+++ b/Example Projects/Simple Integrations Example/Simple Integrations ExampleTests/Simple_Integrations_ExampleTests.m
@@ -1,0 +1,32 @@
+//
+//  Segment-FacebookTests.m
+//  Segment-FacebookTests
+//
+//  Created by Prateek Srivastava on 11/10/2015.
+//  Copyright (c) 2015 Prateek Srivastava. All rights reserved.
+//
+
+@import Specta;
+@import Expecta;
+
+SpecBegin(InitialSpecs)
+
+describe(@"these will pass", ^{
+    
+    it(@"can do maths", ^{
+        expect(1).beLessThan(23);
+    });
+    
+    it(@"can read", ^{
+        expect(@"team").toNot.contain(@"I");
+    });
+    
+    it(@"will wait and succeed", ^{
+        waitUntil(^(DoneCallback done) {
+            done();
+        });
+    });
+});
+
+SpecEnd
+

--- a/Guides/Migrating.md
+++ b/Guides/Migrating.md
@@ -1,0 +1,50 @@
+## Migrate a destination from an old repo to the monorepo
+
+#### 1. Clone the destination you intend to migrate
+```shell
+git clone https://github.com/segment-integrations/analytics-ios-integration-firebase
+```
+#### 2. Clone the monoRepo
+```shell
+git clone https://github.com/segmentio/analytics-ios-integrations
+```
+#### 2. Create new Xcode project, => Choose "Cococa Touch framework" and name project as previous  destination and check the  Objective C and add unit tests boxes.
+
+#### 3. Create new group and name it source and add two new groups, "Core" and "Supporting Files".
+
+#### 4. Move the  destination into the integrations directory where all the source files are under core and .plist and header file, add to supporting files.
+
+#### 5. Add unit tests to test.m
+
+##(At this point project will not run especially since it requires dependencies)
+
+#### 6. Close project and open the iOS-Integrations.xcworkspace in the parent folder, drag the xxxx.xcodeproj to the workspace. It should be added and show as a target but a framework. 
+
+#### 7. Copy the podspec file and set
+
+```
+s.source         = { :git => '' }
+s.source_files = 'Source/**/*'
+s.exclude_files = 'Source/Supporting Files'
+
+``` 
+
+Also update dependencies version to latest if required.
+
+#### 8. Add to pod in the parent folder file the following:
+
+##### a. The relative path of the xxx.xcodeproj
+##### b. The framework and test target.
+##### c. Add the project path again in the framework target
+##### d. Include any shared dependencies or new dependencies.
+
+And run pod install. If successful, running and testing will work correctly. 
+
+#### 9. In example project, add the newly added destination by setting its relative path.
+
+
+
+
+
+
+

--- a/Guides/Releasing.md
+++ b/Guides/Releasing.md
@@ -1,0 +1,10 @@
+# iOS Required Changes for Releasing
+
+
+## Below are some of the required changes needed before release and after adding an integration:
+#### 1. Update the path of `Source` in the pod spec to point to master branch and change version for next release version.
+#### 2. Change path of every added integration(pod) in Example projects pod file from relative path to the published path or git master branch source.
+#### 3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version).
+#### 4. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version).
+#### 5. `git push && git push --tags`.
+#### 6. `pod trunk push xxxx`, where xxxx is the newley added integration podspec.

--- a/Integrations/analytics-ios-integration-facebook-app-events/Segment-Facebook-App-Events.podspec
+++ b/Integrations/analytics-ios-integration-facebook-app-events/Segment-Facebook-App-Events.podspec
@@ -1,0 +1,32 @@
+
+
+Pod::Spec.new do |s|
+  s.name             = "Segment-Facebook-App-Events"
+  s.version          = "1.0.4"
+  s.summary          = "Facebook App Events Integration for Segment's analytics-ios library."
+
+  s.description      = <<-DESC
+                       Analytics for iOS provides a single API that lets you
+                       integrate with over 100s of tools.
+
+                       This is the Facebook App Events integration for the iOS library.
+                       DESC
+
+  s.homepage         = "http://segment.com/"
+  s.license          =  { :type => 'MIT' }
+  s.author           = { "Segment" => "friends@segment.com" }
+ 
+  s.social_media_url = 'https://twitter.com/segment'
+  s.source         = { :git => '' }
+
+  s.platform     = :ios, '8.0'
+  s.requires_arc = true
+
+  s.source_files = 'Source/**/*'
+  s.exclude_files = 'Source/Supporting Files'
+
+  s.dependency 'Analytics', '~> 3.0'
+  s.dependency 'FBSDKCoreKit', '~> 5.0'
+
+  s.pod_target_xcconfig = { 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES' }
+end

--- a/Integrations/analytics-ios-integration-facebook-app-events/Segment-Facebook.xcodeproj/project.pbxproj
+++ b/Integrations/analytics-ios-integration-facebook-app-events/Segment-Facebook.xcodeproj/project.pbxproj
@@ -1,0 +1,669 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 51;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4978C20327426E4A5008D661 /* Pods_Segment_Facebook_Segment_FacebookTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C67EDB3E8F4A5442055CF49 /* Pods_Segment_Facebook_Segment_FacebookTests.framework */; };
+		AABDE7E59695C2A95B0D3721 /* Pods_Segment_Facebook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D763D45B1B98E85BA118E21D /* Pods_Segment_Facebook.framework */; };
+		E072C5682386105D00F90DC6 /* Segment_Facebook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E072C55E2386105D00F90DC6 /* Segment_Facebook.framework */; };
+		E072C56D2386105D00F90DC6 /* Segment_FacebookTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E072C56C2386105D00F90DC6 /* Segment_FacebookTests.m */; };
+		E072C56F2386105D00F90DC6 /* Segment_Facebook.h in Headers */ = {isa = PBXBuildFile; fileRef = E072C5612386105D00F90DC6 /* Segment_Facebook.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E072C57D238610A300F90DC6 /* SEGFacebookAppEventsIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = E072C579238610A300F90DC6 /* SEGFacebookAppEventsIntegration.h */; };
+		E072C57E238610A300F90DC6 /* SEGFacebookAppEventsIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = E072C57A238610A300F90DC6 /* SEGFacebookAppEventsIntegrationFactory.h */; };
+		E072C57F238610A300F90DC6 /* SEGFacebookAppEventsIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = E072C57B238610A300F90DC6 /* SEGFacebookAppEventsIntegration.m */; };
+		E072C580238610A300F90DC6 /* SEGFacebookAppEventsIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E072C57C238610A300F90DC6 /* SEGFacebookAppEventsIntegrationFactory.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		E072C5692386105D00F90DC6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E072C5552386105D00F90DC6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E072C55D2386105D00F90DC6;
+			remoteInfo = "Segment-Facebook";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		089AF6D2D90698A34EB17784 /* Pods-Segment-Facebook.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Facebook.release.xcconfig"; path = "Target Support Files/Pods-Segment-Facebook/Pods-Segment-Facebook.release.xcconfig"; sourceTree = "<group>"; };
+		1DEE5C0456B501E864FFEF25 /* Pods-Segment-Facebook-Segment-FacebookTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Facebook-Segment-FacebookTests.release.xcconfig"; path = "Target Support Files/Pods-Segment-Facebook-Segment-FacebookTests/Pods-Segment-Facebook-Segment-FacebookTests.release.xcconfig"; sourceTree = "<group>"; };
+		3947954B4A0E8FCEC47142F8 /* Pods-Common-Segment-Facebook-Segment-FacebookTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-Segment-Facebook-Segment-FacebookTests.release.xcconfig"; path = "Target Support Files/Pods-Common-Segment-Facebook-Segment-FacebookTests/Pods-Common-Segment-Facebook-Segment-FacebookTests.release.xcconfig"; sourceTree = "<group>"; };
+		551764014D1826EE8FD3DB46 /* Pods-Segment-FacebookTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-FacebookTests.debug.xcconfig"; path = "Target Support Files/Pods-Segment-FacebookTests/Pods-Segment-FacebookTests.debug.xcconfig"; sourceTree = "<group>"; };
+		9C67EDB3E8F4A5442055CF49 /* Pods_Segment_Facebook_Segment_FacebookTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Segment_Facebook_Segment_FacebookTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A16715D16D757D87A83542D3 /* Pods-Segment-Facebook-Segment-FacebookTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Facebook-Segment-FacebookTests.debug.xcconfig"; path = "Target Support Files/Pods-Segment-Facebook-Segment-FacebookTests/Pods-Segment-Facebook-Segment-FacebookTests.debug.xcconfig"; sourceTree = "<group>"; };
+		AA5659B9A9416FCD451C5F5A /* Pods-Common-Segment-Facebook-Segment-FacebookTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-Segment-Facebook-Segment-FacebookTests.debug.xcconfig"; path = "Target Support Files/Pods-Common-Segment-Facebook-Segment-FacebookTests/Pods-Common-Segment-Facebook-Segment-FacebookTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D763D45B1B98E85BA118E21D /* Pods_Segment_Facebook.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Segment_Facebook.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E072C55E2386105D00F90DC6 /* Segment_Facebook.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Segment_Facebook.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E072C5612386105D00F90DC6 /* Segment_Facebook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Segment_Facebook.h; sourceTree = "<group>"; };
+		E072C5622386105D00F90DC6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E072C5672386105D00F90DC6 /* Segment-FacebookTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Segment-FacebookTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E072C56C2386105D00F90DC6 /* Segment_FacebookTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Segment_FacebookTests.m; sourceTree = "<group>"; };
+		E072C56E2386105D00F90DC6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E072C579238610A300F90DC6 /* SEGFacebookAppEventsIntegration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEGFacebookAppEventsIntegration.h; sourceTree = "<group>"; };
+		E072C57A238610A300F90DC6 /* SEGFacebookAppEventsIntegrationFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEGFacebookAppEventsIntegrationFactory.h; sourceTree = "<group>"; };
+		E072C57B238610A300F90DC6 /* SEGFacebookAppEventsIntegration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGFacebookAppEventsIntegration.m; sourceTree = "<group>"; };
+		E072C57C238610A300F90DC6 /* SEGFacebookAppEventsIntegrationFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGFacebookAppEventsIntegrationFactory.m; sourceTree = "<group>"; };
+		E6C27443295D7D7F605398D1 /* Pods-Common-Segment-Facebook.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-Segment-Facebook.debug.xcconfig"; path = "Target Support Files/Pods-Common-Segment-Facebook/Pods-Common-Segment-Facebook.debug.xcconfig"; sourceTree = "<group>"; };
+		E8932F1D209500510A2C74D9 /* Pods-Segment-Facebook.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Facebook.debug.xcconfig"; path = "Target Support Files/Pods-Segment-Facebook/Pods-Segment-Facebook.debug.xcconfig"; sourceTree = "<group>"; };
+		ECD2F5553D4F9BFEDAC1E1AB /* Pods-Common-Segment-Facebook.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common-Segment-Facebook.release.xcconfig"; path = "Target Support Files/Pods-Common-Segment-Facebook/Pods-Common-Segment-Facebook.release.xcconfig"; sourceTree = "<group>"; };
+		F5CA5CC5D4CC5F7829FE87DA /* Pods-Segment-FacebookTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-FacebookTests.release.xcconfig"; path = "Target Support Files/Pods-Segment-FacebookTests/Pods-Segment-FacebookTests.release.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E072C55B2386105D00F90DC6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AABDE7E59695C2A95B0D3721 /* Pods_Segment_Facebook.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E072C5642386105D00F90DC6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E072C5682386105D00F90DC6 /* Segment_Facebook.framework in Frameworks */,
+				4978C20327426E4A5008D661 /* Pods_Segment_Facebook_Segment_FacebookTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		81391500C447EA1EE21D55FE /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				E8932F1D209500510A2C74D9 /* Pods-Segment-Facebook.debug.xcconfig */,
+				089AF6D2D90698A34EB17784 /* Pods-Segment-Facebook.release.xcconfig */,
+				551764014D1826EE8FD3DB46 /* Pods-Segment-FacebookTests.debug.xcconfig */,
+				F5CA5CC5D4CC5F7829FE87DA /* Pods-Segment-FacebookTests.release.xcconfig */,
+				E6C27443295D7D7F605398D1 /* Pods-Common-Segment-Facebook.debug.xcconfig */,
+				ECD2F5553D4F9BFEDAC1E1AB /* Pods-Common-Segment-Facebook.release.xcconfig */,
+				AA5659B9A9416FCD451C5F5A /* Pods-Common-Segment-Facebook-Segment-FacebookTests.debug.xcconfig */,
+				3947954B4A0E8FCEC47142F8 /* Pods-Common-Segment-Facebook-Segment-FacebookTests.release.xcconfig */,
+				A16715D16D757D87A83542D3 /* Pods-Segment-Facebook-Segment-FacebookTests.debug.xcconfig */,
+				1DEE5C0456B501E864FFEF25 /* Pods-Segment-Facebook-Segment-FacebookTests.release.xcconfig */,
+			);
+			name = Pods;
+			path = ../../Pods;
+			sourceTree = "<group>";
+		};
+		E0229B3E23BA386D00CB0EB0 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				E072C5612386105D00F90DC6 /* Segment_Facebook.h */,
+				E072C5622386105D00F90DC6 /* Info.plist */,
+			);
+			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		E0229B3F23BA388100CB0EB0 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				E072C579238610A300F90DC6 /* SEGFacebookAppEventsIntegration.h */,
+				E072C57B238610A300F90DC6 /* SEGFacebookAppEventsIntegration.m */,
+				E072C57A238610A300F90DC6 /* SEGFacebookAppEventsIntegrationFactory.h */,
+				E072C57C238610A300F90DC6 /* SEGFacebookAppEventsIntegrationFactory.m */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		E072C5542386105D00F90DC6 = {
+			isa = PBXGroup;
+			children = (
+				E072C5782386108700F90DC6 /* Source */,
+				E072C56B2386105D00F90DC6 /* Segment-FacebookTests */,
+				E072C55F2386105D00F90DC6 /* Products */,
+				E31F433A916588511ED378CB /* Frameworks */,
+				81391500C447EA1EE21D55FE /* Pods */,
+			);
+			sourceTree = "<group>";
+		};
+		E072C55F2386105D00F90DC6 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E072C55E2386105D00F90DC6 /* Segment_Facebook.framework */,
+				E072C5672386105D00F90DC6 /* Segment-FacebookTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E072C56B2386105D00F90DC6 /* Segment-FacebookTests */ = {
+			isa = PBXGroup;
+			children = (
+				E072C56C2386105D00F90DC6 /* Segment_FacebookTests.m */,
+				E072C56E2386105D00F90DC6 /* Info.plist */,
+			);
+			path = "Segment-FacebookTests";
+			sourceTree = "<group>";
+		};
+		E072C5782386108700F90DC6 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				E0229B3F23BA388100CB0EB0 /* Core */,
+				E0229B3E23BA386D00CB0EB0 /* Supporting Files */,
+			);
+			path = Source;
+			sourceTree = "<group>";
+		};
+		E31F433A916588511ED378CB /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D763D45B1B98E85BA118E21D /* Pods_Segment_Facebook.framework */,
+				9C67EDB3E8F4A5442055CF49 /* Pods_Segment_Facebook_Segment_FacebookTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		E072C5592386105D00F90DC6 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E072C57D238610A300F90DC6 /* SEGFacebookAppEventsIntegration.h in Headers */,
+				E072C56F2386105D00F90DC6 /* Segment_Facebook.h in Headers */,
+				E072C57E238610A300F90DC6 /* SEGFacebookAppEventsIntegrationFactory.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		E072C55D2386105D00F90DC6 /* Segment-Facebook */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E072C5722386105D00F90DC6 /* Build configuration list for PBXNativeTarget "Segment-Facebook" */;
+			buildPhases = (
+				2FD3201C7EA7D731BA24D886 /* [CP] Check Pods Manifest.lock */,
+				E072C5592386105D00F90DC6 /* Headers */,
+				E072C55A2386105D00F90DC6 /* Sources */,
+				E072C55B2386105D00F90DC6 /* Frameworks */,
+				E072C55C2386105D00F90DC6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Segment-Facebook";
+			productName = "Segment-Facebook";
+			productReference = E072C55E2386105D00F90DC6 /* Segment_Facebook.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		E072C5662386105D00F90DC6 /* Segment-FacebookTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E072C5752386105D00F90DC6 /* Build configuration list for PBXNativeTarget "Segment-FacebookTests" */;
+			buildPhases = (
+				83708EC492D1CE8303DABA47 /* [CP] Check Pods Manifest.lock */,
+				E072C5632386105D00F90DC6 /* Sources */,
+				E072C5642386105D00F90DC6 /* Frameworks */,
+				E072C5652386105D00F90DC6 /* Resources */,
+				73FD6DD022F447A1BCE5F3EB /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E072C56A2386105D00F90DC6 /* PBXTargetDependency */,
+			);
+			name = "Segment-FacebookTests";
+			productName = "Segment-FacebookTests";
+			productReference = E072C5672386105D00F90DC6 /* Segment-FacebookTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E072C5552386105D00F90DC6 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1030;
+				ORGANIZATIONNAME = Segment;
+				TargetAttributes = {
+					E072C55D2386105D00F90DC6 = {
+						CreatedOnToolsVersion = 10.3;
+					};
+					E072C5662386105D00F90DC6 = {
+						CreatedOnToolsVersion = 10.3;
+					};
+				};
+			};
+			buildConfigurationList = E072C5582386105D00F90DC6 /* Build configuration list for PBXProject "Segment-Facebook" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = E072C5542386105D00F90DC6;
+			productRefGroup = E072C55F2386105D00F90DC6 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E072C55D2386105D00F90DC6 /* Segment-Facebook */,
+				E072C5662386105D00F90DC6 /* Segment-FacebookTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E072C55C2386105D00F90DC6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E072C5652386105D00F90DC6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		2FD3201C7EA7D731BA24D886 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Segment-Facebook-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		73FD6DD022F447A1BCE5F3EB /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Segment-Facebook-Segment-FacebookTests/Pods-Segment-Facebook-Segment-FacebookTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Segment-Facebook-Segment-FacebookTests/Pods-Segment-Facebook-Segment-FacebookTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Segment-Facebook-Segment-FacebookTests/Pods-Segment-Facebook-Segment-FacebookTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		83708EC492D1CE8303DABA47 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Segment-Facebook-Segment-FacebookTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E072C55A2386105D00F90DC6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E072C580238610A300F90DC6 /* SEGFacebookAppEventsIntegrationFactory.m in Sources */,
+				E072C57F238610A300F90DC6 /* SEGFacebookAppEventsIntegration.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E072C5632386105D00F90DC6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E072C56D2386105D00F90DC6 /* Segment_FacebookTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E072C56A2386105D00F90DC6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E072C55D2386105D00F90DC6 /* Segment-Facebook */;
+			targetProxy = E072C5692386105D00F90DC6 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		E072C5702386105D00F90DC6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		E072C5712386105D00F90DC6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		E072C5732386105D00F90DC6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E8932F1D209500510A2C74D9 /* Pods-Segment-Facebook.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					"\"Analytics\"",
+					"-framework",
+					"\"CoreTelephony\"",
+					"-framework",
+					"\"FBSDKCoreKit\"",
+					"-framework",
+					"\"Foundation\"",
+					"-framework",
+					"\"Security\"",
+					"-framework",
+					"\"StoreKit\"",
+					"-framework",
+					"\"SystemConfiguration\"",
+					"-framework",
+					"\"UIKit\"",
+					"-weak_framework",
+					"\"Accounts\"",
+					"-weak_framework",
+					"\"AudioToolbox\"",
+					"-weak_framework",
+					"\"CoreGraphics\"",
+					"-weak_framework",
+					"\"CoreLocation\"",
+					"-weak_framework",
+					"\"Foundation\"",
+					"-weak_framework",
+					"\"QuartzCore\"",
+					"-weak_framework",
+					"\"Security\"",
+					"-weak_framework",
+					"\"Social\"",
+					"-weak_framework",
+					"\"UIKit\"",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Segment.Segment-Facebook";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E072C5742386105D00F90DC6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 089AF6D2D90698A34EB17784 /* Pods-Segment-Facebook.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					"\"Analytics\"",
+					"-framework",
+					"\"CoreTelephony\"",
+					"-framework",
+					"\"FBSDKCoreKit\"",
+					"-framework",
+					"\"Foundation\"",
+					"-framework",
+					"\"Security\"",
+					"-framework",
+					"\"StoreKit\"",
+					"-framework",
+					"\"SystemConfiguration\"",
+					"-framework",
+					"\"UIKit\"",
+					"-weak_framework",
+					"\"Accounts\"",
+					"-weak_framework",
+					"\"AudioToolbox\"",
+					"-weak_framework",
+					"\"CoreGraphics\"",
+					"-weak_framework",
+					"\"CoreLocation\"",
+					"-weak_framework",
+					"\"Foundation\"",
+					"-weak_framework",
+					"\"QuartzCore\"",
+					"-weak_framework",
+					"\"Security\"",
+					"-weak_framework",
+					"\"Social\"",
+					"-weak_framework",
+					"\"UIKit\"",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Segment.Segment-Facebook";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		E072C5762386105D00F90DC6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A16715D16D757D87A83542D3 /* Pods-Segment-Facebook-Segment-FacebookTests.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Segment-FacebookTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Segment.Segment-FacebookTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E072C5772386105D00F90DC6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DEE5C0456B501E864FFEF25 /* Pods-Segment-Facebook-Segment-FacebookTests.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Segment-FacebookTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Segment.Segment-FacebookTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E072C5582386105D00F90DC6 /* Build configuration list for PBXProject "Segment-Facebook" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E072C5702386105D00F90DC6 /* Debug */,
+				E072C5712386105D00F90DC6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E072C5722386105D00F90DC6 /* Build configuration list for PBXNativeTarget "Segment-Facebook" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E072C5732386105D00F90DC6 /* Debug */,
+				E072C5742386105D00F90DC6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E072C5752386105D00F90DC6 /* Build configuration list for PBXNativeTarget "Segment-FacebookTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E072C5762386105D00F90DC6 /* Debug */,
+				E072C5772386105D00F90DC6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = E072C5552386105D00F90DC6 /* Project object */;
+}

--- a/Integrations/analytics-ios-integration-facebook-app-events/Segment-Facebook.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Integrations/analytics-ios-integration-facebook-app-events/Segment-Facebook.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Segment-Facebook.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Integrations/analytics-ios-integration-facebook-app-events/Segment-Facebook.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Integrations/analytics-ios-integration-facebook-app-events/Segment-Facebook.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Integrations/analytics-ios-integration-facebook-app-events/Segment-FacebookTests/Info.plist
+++ b/Integrations/analytics-ios-integration-facebook-app-events/Segment-FacebookTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Integrations/analytics-ios-integration-facebook-app-events/Segment-FacebookTests/Segment_FacebookTests.m
+++ b/Integrations/analytics-ios-integration-facebook-app-events/Segment-FacebookTests/Segment_FacebookTests.m
@@ -1,0 +1,32 @@
+//
+//  Segment-FacebookTests.m
+//  Segment-FacebookTests
+//
+//  Created by Prateek Srivastava on 11/10/2015.
+//  Copyright (c) 2015 Prateek Srivastava. All rights reserved.
+//
+
+@import Specta;
+@import Expecta;
+
+SpecBegin(InitialSpecs)
+
+describe(@"these will pass", ^{
+    
+    it(@"can do maths", ^{
+        expect(1).beLessThan(23);
+    });
+    
+    it(@"can read", ^{
+       expect(@"team").toNot.contain(@"I");
+    });
+    
+    it(@"will wait and succeed", ^{
+        waitUntil(^(DoneCallback done) {
+            done();
+        });
+    });
+});
+
+SpecEnd
+

--- a/Integrations/analytics-ios-integration-facebook-app-events/Source/Core/SEGFacebookAppEventsIntegration.h
+++ b/Integrations/analytics-ios-integration-facebook-app-events/Source/Core/SEGFacebookAppEventsIntegration.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+#import <Analytics/SEGIntegration.h>
+
+@interface SEGFacebookAppEventsIntegration : NSObject<SEGIntegration>
+
+@property(nonatomic, strong) NSDictionary *settings;
+
+- (id)initWithSettings:(NSDictionary *)settings;
+
+@end

--- a/Integrations/analytics-ios-integration-facebook-app-events/Source/Core/SEGFacebookAppEventsIntegration.m
+++ b/Integrations/analytics-ios-integration-facebook-app-events/Source/Core/SEGFacebookAppEventsIntegration.m
@@ -1,0 +1,106 @@
+#import "SEGFacebookAppEventsIntegration.h"
+#import <FBSDKCoreKit/FBSDKCoreKit.h>
+#import <Analytics/SEGAnalyticsUtils.h>
+
+@implementation SEGFacebookAppEventsIntegration
+
+#pragma mark - Initialization
+
+- (id)initWithSettings:(NSDictionary *)settings
+{
+    if (self = [super init]) {
+        self.settings = settings;
+        
+        NSString *appId = [settings objectForKey:@"appId"];
+        [FBSDKSettings setAppID:appId];
+    }
+    return self;
+}
+
++ (NSNumber *)extractRevenue:(NSDictionary *)dictionary withKey:(NSString *)revenueKey
+{
+    id revenueProperty = nil;
+    
+    for (NSString *key in dictionary.allKeys) {
+        if ([key caseInsensitiveCompare:revenueKey] == NSOrderedSame) {
+            revenueProperty = dictionary[key];
+            break;
+        }
+    }
+    
+    if (revenueProperty) {
+        if ([revenueProperty isKindOfClass:[NSString class]]) {
+            // Format the revenue.
+            NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+            [formatter setNumberStyle:NSNumberFormatterDecimalStyle];
+            return [formatter numberFromString:revenueProperty];
+        } else if ([revenueProperty isKindOfClass:[NSNumber class]]) {
+            return revenueProperty;
+        }
+    }
+    return nil;
+}
+
++ (NSString *)extractCurrency:(NSDictionary *)dictionary withKey:(NSString *)currencyKey
+{
+    id currencyProperty = nil;
+    
+    for (NSString *key in dictionary.allKeys) {
+        if ([key caseInsensitiveCompare:currencyKey] == NSOrderedSame) {
+            currencyProperty = dictionary[key];
+            return currencyProperty;
+        }
+    }
+
+    // default to USD
+    return @"USD";
+}
+
+- (void)track:(SEGTrackPayload *)payload
+{
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+        // FB Event Names must be <= 40 characters
+        NSString *truncatedEvent = [payload.event substringToIndex: MIN(40, [payload.event length])];
+        
+        // Revenue & currency tracking
+        NSNumber *revenue = [SEGFacebookAppEventsIntegration extractRevenue:payload.properties withKey:@"revenue"];
+        NSString *currency = [SEGFacebookAppEventsIntegration extractCurrency:payload.properties withKey:@"currency"];
+        if (revenue) {
+            [FBSDKAppEvents logPurchase:[revenue doubleValue] currency:currency];
+        
+            // Custom event
+            NSMutableDictionary *properties = [payload.properties mutableCopy];
+            [properties setObject:currency forKey:FBSDKAppEventParameterNameCurrency];
+            [FBSDKAppEvents logEvent:truncatedEvent
+                            valueToSum:[revenue doubleValue]
+                            parameters:properties];
+        }
+        else {
+            [FBSDKAppEvents logEvent:truncatedEvent
+                            parameters:payload.properties];
+        }
+    }];
+}
+
+- (void)screen:(SEGScreenPayload *)payload
+{
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+        // FB Event Names must be <= 40 characters
+        // 'Viewed' and 'Screen' with spaces take up 14
+        NSString *truncatedEvent = [payload.name substringToIndex: MIN(26, [payload.name length])];
+        NSString *event = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", truncatedEvent];
+        [FBSDKAppEvents logEvent:event];
+    }];
+    
+}
+
+#pragma mark - Callbacks for app state changes
+
+- (void)applicationDidBecomeActive
+{
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+        [FBSDKAppEvents activateApp];
+    }];
+}
+
+@end

--- a/Integrations/analytics-ios-integration-facebook-app-events/Source/Core/SEGFacebookAppEventsIntegrationFactory.h
+++ b/Integrations/analytics-ios-integration-facebook-app-events/Source/Core/SEGFacebookAppEventsIntegrationFactory.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#import <Analytics/SEGIntegrationFactory.h>
+
+@interface SEGFacebookAppEventsIntegrationFactory : NSObject<SEGIntegrationFactory>
+
++ (instancetype)instance;
+
+@end

--- a/Integrations/analytics-ios-integration-facebook-app-events/Source/Core/SEGFacebookAppEventsIntegrationFactory.m
+++ b/Integrations/analytics-ios-integration-facebook-app-events/Source/Core/SEGFacebookAppEventsIntegrationFactory.m
@@ -1,0 +1,32 @@
+#import "SEGFacebookAppEventsIntegrationFactory.h"
+#import "SEGFacebookAppEventsIntegration.h"
+
+@implementation SEGFacebookAppEventsIntegrationFactory
+
++ (instancetype)instance
+{
+    static dispatch_once_t once;
+    static SEGFacebookAppEventsIntegrationFactory *sharedInstance;
+    dispatch_once(&once, ^{
+        sharedInstance = [[self alloc] init];
+    });
+    return sharedInstance;
+}
+
+- (id)init
+{
+    self = [super init];
+    return self;
+}
+
+- (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics
+{
+    return [[SEGFacebookAppEventsIntegration alloc] initWithSettings:settings];
+}
+
+- (NSString *)key
+{
+    return @"Facebook App Events";
+}
+
+@end

--- a/Integrations/analytics-ios-integration-facebook-app-events/Source/Supporting Files/Info.plist
+++ b/Integrations/analytics-ios-integration-facebook-app-events/Source/Supporting Files/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Integrations/analytics-ios-integration-facebook-app-events/Source/Supporting Files/Segment_Facebook.h
+++ b/Integrations/analytics-ios-integration-facebook-app-events/Source/Supporting Files/Segment_Facebook.h
@@ -1,0 +1,19 @@
+//
+//  Segment_Facebook.h
+//  Segment-Facebook
+//
+//  Created by Olla Ashour on 11/21/19.
+//  Copyright © 2019 Segment. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for Segment_Facebook.
+FOUNDATION_EXPORT double Segment_FacebookVersionNumber;
+
+//! Project version string for Segment_Facebook.
+FOUNDATION_EXPORT const unsigned char Segment_FacebookVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Segment_Facebook/PublicHeader.h>
+
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Segment
+Copyright (c) 2020 Segment
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,33 @@
+# Uncomment the next line to define a global platform for your project
+
+platform :ios, '9.0'
+
+workspace 'iOS-Integrations.xcworkspace'
+project 'Integrations/analytics-ios-integration-facebook-app-events/Segment-Facebook.xcodeproj'
+use_frameworks!
+
+def shared_pods
+  pod 'Analytics', '~> 3.0'
+end
+
+def testing_pods
+  pod 'Expecta'
+  pod 'Specta'
+end
+
+shared_pods
+
+target 'Segment-Facebook' do
+  
+  project 'Integrations/analytics-ios-integration-facebook-app-events/Segment-Facebook.xcodeproj'
+  pod 'FBSDKCoreKit', '~> 5.0'
+ 
+ target 'Segment-FacebookTests' do
+  testing_pods
+  end
+end
+
+
+
+
+

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,33 @@
+PODS:
+  - Analytics (3.7.0)
+  - Expecta (1.0.6)
+  - FBSDKCoreKit (5.13.1):
+    - FBSDKCoreKit/Basics (= 5.13.1)
+    - FBSDKCoreKit/Core (= 5.13.1)
+  - FBSDKCoreKit/Basics (5.13.1)
+  - FBSDKCoreKit/Core (5.13.1):
+    - FBSDKCoreKit/Basics
+  - Specta (1.0.7)
+
+DEPENDENCIES:
+  - Analytics (~> 3.0)
+  - Expecta
+  - FBSDKCoreKit (~> 5.0)
+  - Specta
+
+SPEC REPOS:
+  trunk:
+    - Analytics
+    - Expecta
+    - FBSDKCoreKit
+    - Specta
+
+SPEC CHECKSUMS:
+  Analytics: 77fd5fb102a4a5eedafa2c2b0245ceb7b7c15e45
+  Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
+  FBSDKCoreKit: 8fb98209109fb684937f05d534305edb18c20207
+  Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
+
+PODFILE CHECKSUM: 6b969646294d8bb3aab2b422f522e2a513dce7ec
+
+COCOAPODS: 1.8.4

--- a/iOS-Integrations.xcworkspace/contents.xcworkspacedata
+++ b/iOS-Integrations.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Integrations/analytics-ios-integration-facebook-app-events/Segment-Facebook.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/iOS-Integrations.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/iOS-Integrations.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
* DAND-50-Setup iOS Project workspace, add facebook-events as a framework, add example project, add targets in workspace, configure pod file to work with targets, update tests.

* DAND-16-Update podspec and pod file to combine two ways

* DAND-16-Another attempt at getting the example project to see the pods.

* DAND-16- Testing out monoRepo structure with podspec on same parent directory

* DAND-16-Move Podspec into child repository, remove example from workspace file and create a simple workspace file for example

* DAND-16-Update example

* DAND-16-Rename "Segment-Facebook" to "Segment-Facebook-App-Events" and integration folder to "analytics-iOS-integration-facebook-app-events"

* DAND-16-Remove all tracking of pods in project

* DAND-16-Update Migrating.md to document migrating a destination into the monorepo

* DAND-46-Update Migrating.md to document migrating a destination into the monorepo

* DAND-49-Add part of the documentation for release changes